### PR TITLE
httpc: Changed how downloads larger than the provided buffer are handled

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -44,6 +44,7 @@ static std::shared_ptr<Logger> global_logger;
         SUB(Service, CFG) \
         SUB(Service, DSP) \
         SUB(Service, HID) \
+        SUB(Service, HTTP) \
         SUB(Service, SOC) \
         CLS(HW) \
         SUB(HW, Memory) \

--- a/src/core/hle/service/http/http.cpp
+++ b/src/core/hle/service/http/http.cpp
@@ -26,7 +26,7 @@ static int BufWriter(u8 *data, size_t size, size_t nmemb, std::vector<u8>* out_b
 
 HttpContext::HttpContext() {
     state = RequestState::NOT_STARTED;
-    cancel_request = false;
+    cancel_request.store(false);
     request_type = RequestType::None;
     request_headers = nullptr;
     response_code = 0;
@@ -104,7 +104,7 @@ void MakeRequest(HttpContext* context) {
 
         {
             std::lock_guard<std::mutex> lock(context->mutex);
-            if (context->cancel_request)
+            if (context->cancel_request.load())
                 break;
         }
 
@@ -142,7 +142,7 @@ void Init() {
 
 void ClearInstance() {
     for (auto& pair : context_map) {
-        pair.second->cancel_request = true;
+        pair.second->cancel_request.store(true);
     }
 
     for (auto& pair : context_map) {

--- a/src/core/hle/service/http/http.cpp
+++ b/src/core/hle/service/http/http.cpp
@@ -27,11 +27,12 @@ static int BufWriter(u8 *data, size_t size, size_t nmemb, std::vector<u8>* out_b
 HttpContext::HttpContext() {
     state = RequestState::NOT_STARTED;
     cancel_request = false;
-    request_type = RequestType::NONE;
+    request_type = RequestType::None;
     request_headers = nullptr;
     response_code = 0;
     content_length = 0.0;
     downloaded_size = 0.0;
+    current_content_length = 0;
 }
 
 HttpContext::~HttpContext() {
@@ -40,17 +41,17 @@ HttpContext::~HttpContext() {
 
 static CURLcode SetConnectionType(CURL* connection, RequestType type) {
     switch (type) {
-    case RequestType::GET:
+    case RequestType::Get:
         return curl_easy_setopt(connection, CURLOPT_HTTPGET, 1);
-    case RequestType::POST:
-    case RequestType::POST_ALT:
+    case RequestType::Post:
+    case RequestType::Post_Alt:
         return curl_easy_setopt(connection, CURLOPT_POST, 1);
-    case RequestType::PUT:
-    case RequestType::PUT_ALT:
+    case RequestType::Put:
+    case RequestType::Put_Alt:
         return curl_easy_setopt(connection, CURLOPT_UPLOAD, 1);
-    case RequestType::DELETE:
+    case RequestType::Delete:
         break; // TODO
-    case RequestType::HEAD:
+    case RequestType::Head:
         return curl_easy_setopt(connection, CURLOPT_NOBODY, 1);
     }
 }
@@ -118,7 +119,7 @@ void MakeRequest(HttpContext* context) {
         res = curl_easy_getinfo(connection, CURLINFO_RESPONSE_CODE, &context->response_code);
         res = curl_easy_getinfo(connection, CURLINFO_SIZE_DOWNLOAD, &context->downloaded_size);
         res = curl_easy_getinfo(connection, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &context->content_length);
-
+        context->current_content_length = 0;
         context->state = RequestState::READY;
     }
 

--- a/src/core/hle/service/http/http.h
+++ b/src/core/hle/service/http/http.h
@@ -10,6 +10,7 @@
 #include <thread>
 #include <string>
 #include <unordered_map>
+#include <atomic>
 
 #include "core/hle/result.h"
 
@@ -51,7 +52,7 @@ struct HttpContext {
     //--- Ongoing request management
     RequestState state;               //< API-exposed current state of the HTTP request
     std::unique_ptr<std::thread> request_thread;
-    bool cancel_request;              //< True if the request's thread should be canceled ASAP
+    std::atomic<bool> cancel_request;              //< True if the request's thread should be canceled ASAP
 
     //--- Request data
     std::string url;                  //< URL to the target server.

--- a/src/core/hle/service/http/http.h
+++ b/src/core/hle/service/http/http.h
@@ -22,14 +22,14 @@ typedef u32 ContextHandle;
 
 /// HTTP operation that will be performed by the request (API-exposed).
 enum class RequestType : u32 {
-    NONE     = 0,
-    GET      = 1,
-    POST     = 2,
-    HEAD     = 3,
-    PUT      = 4,
-    DELETE   = 5,
-    POST_ALT = 6,
-    PUT_ALT  = 7
+    None     = 0,
+    Get      = 1,
+    Post     = 2,
+    Head     = 3,
+    Put      = 4,
+    Delete   = 5,
+    Post_Alt = 6,
+    Put_Alt  = 7
 };
 
 /// Current state of the HTTP request (API-exposed).
@@ -64,6 +64,8 @@ struct HttpContext {
     long response_code;               //< The three-digit HTTP response code returned by the server.
     double content_length;            //< The total size in bytes that will be downloaded this request (cURL returns a double for this).
     double downloaded_size;           //< The amount in bytes that has been downloaded so far (cURL returns a double for this).
+
+    long current_content_length;      //< The amount in bytes that has been read out of the http response_data
 
     HttpContext();
     ~HttpContext();

--- a/src/core/hle/service/http/http_c.cpp
+++ b/src/core/hle/service/http/http_c.cpp
@@ -149,7 +149,7 @@ static void ReceiveData(Service::Interface* self) {
     auto context = map_it->second.get();
 
     std::lock_guard<std::mutex> lock(map_it->second->mutex);
-    const std::vector<u8>& data = context->response_data;
+    auto& data = context->response_data;
 
     // TODO: Check if this should use context->downloaded_size instead of data.size()
     if (buf_size > data.size()) {
@@ -215,7 +215,6 @@ static void GetResponseStatusCode(Service::Interface* self) {
         return;
     }
 
-    // TODO: Verify behavior
     while (true) {
         std::lock_guard<std::mutex> lock(map_it->second->mutex);
         if (map_it->second->state == RequestState::READY)

--- a/src/core/hle/service/http/http_c.cpp
+++ b/src/core/hle/service/http/http_c.cpp
@@ -51,7 +51,8 @@ static void CloseContext(Service::Interface* self) {
         return;
     }
 
-    map_it->second->cancel_request = true;
+    map_it->second->cancel_request.store(true);
+
     if (map_it->second->request_thread != nullptr)
         map_it->second->request_thread->join();
 
@@ -70,7 +71,7 @@ static void CancelConnection(Service::Interface* self) {
         cmd_buff[1] = 0xD8E007F7;
         return;
     }
-    map_it->second->cancel_request = true;
+    map_it->second->cancel_request.store(true);
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
 }


### PR DESCRIPTION
Changed the RequestType to lowercase, because DELETE is defined in winnt.h which is included in winsock2.h.

Changed the behavior of GetDownloadSizeState to return the current size of the data that has been copied out of the response_data buffer.

Changed the behavior of ReceiveData,

If the buffer is larger than the downloaded data size wait for more to be downloaded. (check downloaded size instead?)

If the data is larger than the buffer, fill the buffer, and increment an internal counter to advance through the response data.

Tested with Homebrew Browser, was able to download app, and then run them.
